### PR TITLE
Fix movie listing pagination total count

### DIFF
--- a/src/modules/Movies/movie.controller.ts
+++ b/src/modules/Movies/movie.controller.ts
@@ -75,10 +75,10 @@ export class MovieController {
                 throw new NotFoundError('No se encontraron películas con los filtros proporcionados');
             }
             return ResponseHandler.paginated(
-                res, 
-                result.movies, 
-                result.movies.length, 
-                query.page, 
+                res,
+                result.movies,
+                result.total,
+                query.page,
                 query.limit,
             );
         } catch (error) {

--- a/src/modules/Movies/movie.dao.ts
+++ b/src/modules/Movies/movie.dao.ts
@@ -84,6 +84,7 @@ export class MovieDAO {
         return {
             currentPage: query.page,
             totalPages: Math.ceil(totalMovies / query.limit),
+            total: totalMovies,
             movies,
         };
     }

--- a/src/modules/Movies/movie.dtos.ts
+++ b/src/modules/Movies/movie.dtos.ts
@@ -45,6 +45,7 @@ export type MovieParams = z.infer<typeof idParamsSchema>;
 export interface movieList {
     currentPage: number;
     totalPages: number;
+    total: number;
     movies: Movie[];
 }
 export interface MovieFilters {


### PR DESCRIPTION
## Summary
- return total movie count from movie DAO
- include total in movie list DTO
- use reported total to build paginated responses

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a11fc752208331bd3fd987ad8aad5a